### PR TITLE
Added compression for the PlayerCover URL data to allow the base64 to…

### DIFF
--- a/TouchPortalYTMusic/TPYTMD.py
+++ b/TouchPortalYTMusic/TPYTMD.py
@@ -1,4 +1,5 @@
 import base64
+import zlib
 import json
 import os
 import threading
@@ -89,7 +90,7 @@ def stateUpdate():
                 oldMusicTitle = (statesData['track']['title'], queryQueue['currentIndex']);
                 #print(oldMusicTitle, statesData['track']['title'])
                 if statesData['track']['cover']:
-                    TPClient.stateUpdate("KillerBOSS.TouchPortal.Plugin.YTMD.States.Playercover", base64.b64encode(requests.get(statesData['track']['cover']).content).decode('utf-8'))
+                    TPClient.stateUpdate("KillerBOSS.TouchPortal.Plugin.YTMD.States.Playercover", base64.b64encode(zlib.compress(requests.get(statesData['track']['cover']).content)).decode('utf-8'))
                 if isBeta:
                     YTMD_Actions("show-lyrics-hidden", showdata=False)
                     HiddenLyrics = True


### PR DESCRIPTION
… be readable by TouchPortal

- This is untested as I can't seem to get the plugin to compile properly, but it was a seemingly simple fix and should work.