### PR TITLE
Open / Close YTMD app by block

### DIFF
--- a/TouchPortalYTMusic/TPYTMD.py
+++ b/TouchPortalYTMusic/TPYTMD.py
@@ -35,7 +35,7 @@ def YTMD_Actions(command,value=None, showdata=True):
         print(f'Running Command: {command} Value: {value} Status Code: {status.status}')
         writeServerData(f'Running Command: {command} Value: {value} Status Code: {status.status}')
 
-def openClose():
+def showHide():
     for x in range(0,2):
         keyboard.press(Key.media_play_pause)
         keyboard.release(Key.media_play_pause)
@@ -320,8 +320,8 @@ def Actions(data):
             YTMD_Actions("play-url", data['data'][0]['value'])
         if data['actionId'] == "KillerBOSS.TouchPortal.Plugin.YTMD.Action.SkipAd":
             YTMD_Actions("skip-ad")
-        if data['actionId'] == "KillerBOSS.TouchPortal.Plugin.YTMD.Action.Open/Close":
-            openClose()
+        if data['actionId'] == "KillerBOSS.TouchPortal.Plugin.YTMD.Action.Show/Hide":
+            showHide()
 
 @TPClient.on(TYPES.onConnectorChange)
 def connectorManager(data):

--- a/TouchPortalYTMusic/TPYTMD.py
+++ b/TouchPortalYTMusic/TPYTMD.py
@@ -8,6 +8,7 @@ import urllib3
 from TouchPortalAPI import TYPES
 import requests
 from sys import exit
+from pynput.keyboard import Controller, Key
 
 YTMD_server = "localhost"
 LoginPass = None
@@ -17,6 +18,7 @@ statesData = ""
 http = urllib3.PoolManager(num_pools=10)
 isYTMDRunning = False
 running = False
+keyboard = Controller()
 
 def writeServerData(Serverinfo):
     currenttime = (strftime('[%I:%M:%S:%p] '))
@@ -32,6 +34,11 @@ def YTMD_Actions(command,value=None, showdata=True):
     if showdata:
         print(f'Running Command: {command} Value: {value} Status Code: {status.status}')
         writeServerData(f'Running Command: {command} Value: {value} Status Code: {status.status}')
+
+def openClose():
+    for x in range(0,2):
+        keyboard.press(Key.media_play_pause)
+        keyboard.release(Key.media_play_pause)
 
 TPClient = TouchPortalAPI.Client("YoutubeMusic")
 
@@ -313,6 +320,8 @@ def Actions(data):
             YTMD_Actions("play-url", data['data'][0]['value'])
         if data['actionId'] == "KillerBOSS.TouchPortal.Plugin.YTMD.Action.SkipAd":
             YTMD_Actions("skip-ad")
+        if data['actionId'] == "KillerBOSS.TouchPortal.Plugin.YTMD.Action.Open/Close":
+            openClose()
 
 @TPClient.on(TYPES.onConnectorChange)
 def connectorManager(data):

--- a/TouchPortalYTMusic/build.py
+++ b/TouchPortalYTMusic/build.py
@@ -67,7 +67,7 @@ PLUGIN_ICON = "icon.png"
 OUTPUT_PATH = r"./"
 
 """ PLUGIN_VERSION: A version string for the generated .tpp file name. This example reads the `__version__` from the example plugin's code. """
-PLUGIN_VERSION = "2.2.0"
+PLUGIN_VERSION = "2.2.1"
 
 # Or just set the PLUGIN_VERSION manually.
 # PLUGIN_VERSION = "1.0.0-beta1"

--- a/TouchPortalYTMusic/entry.tp
+++ b/TouchPortalYTMusic/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 6,
-  "version": 220,
+  "version": 221,
   "name": "YouTube Music Desktop plugin",
   "id": "YoutubeMusic",
   "configuration": {
@@ -31,7 +31,8 @@
       "type": "text",
       "default": "YTMD is Not open",
       "readOnly": true
-    }],
+    }
+  ],
   "plugin_start_cmd_windows": "%TP_PLUGIN_FOLDER%TouchPortalYTMusic\\TPYTMD.exe",
   "plugin_start_cmd_mac": "sh %TP_PLUGIN_FOLDER%TouchPortalYTMusic//start.sh TPYTMD",
   "plugin_start_cmd_linux": "sh %TP_PLUGIN_FOLDER%TouchPortalYTMusic//start.sh TPYTMD",
@@ -309,6 +310,13 @@
           "name": "YT Music Playback Shuffle",
           "format": "Shuffle Current playlist",
           "type": "communicate"
+        },
+        {
+            "id":"KillerBOSS.TouchPortal.Plugin.YTMD.Action.Open/Close",
+            "name":"YT Music App Open/Close",
+            "prefix":"YT Music",
+            "type":"communicate",
+            "format":"Open/Close The App"
         }
       ],
       "events": [

--- a/TouchPortalYTMusic/entry.tp
+++ b/TouchPortalYTMusic/entry.tp
@@ -312,11 +312,11 @@
           "type": "communicate"
         },
         {
-            "id":"KillerBOSS.TouchPortal.Plugin.YTMD.Action.Open/Close",
-            "name":"YT Music App Open/Close",
+            "id":"KillerBOSS.TouchPortal.Plugin.YTMD.Action.Show/Hide",
+            "name":"YT Music App Show/Hide",
             "prefix":"YT Music",
             "type":"communicate",
-            "format":"Open/Close The App"
+            "format":"Show/Hide The App"
         }
       ],
       "events": [


### PR DESCRIPTION
This simply allows YTMD to be shown / hidden through the use of a single (toggle) block. It uses the Play/Pause media key as its hotkey to do so.